### PR TITLE
Bump build number to 1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     
 build:
   skip: True  # [win and py2k]
-  number: 0
+  number: 1
   script: python setup.py install  --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
Rebuild in the presence of the SVML patched `llvmdev` to deliver this
functionality in `llvmlite` for use with `numba`.

cc @anton-malakhov @stuartarchibald @seibert @isuruf 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/llvmdev-feedstock/pull/37