### PR TITLE
Simplify recipe based on llvmdev

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,14 +14,13 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py==27]
+  skip: true  # [win and vc<14]
 
 requirements:
   build:
-    - {{ compiler('c') }}    # [unix or (win and py==27)]
-    - {{ compiler('cxx') }}  # [unix or (win and py==27)]
-    - vs2017_win-64          # [win64 and py>27]
-    - vs2017_win-32          # [win32 and py>27]
+    - {{ compiler('c') }}            # [unix]
+    - {{ compiler('cxx') }}          # [unix]
+    - vs2017_{{ target_platform  }}  # [win]
     # The DLL build uses cmake on Windows
     - cmake                  # [win]
     - make                   # [unix]


### PR DESCRIPTION
Small implications to recipe based on llvmdev's compiler selection.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Small cleanup based on llvmdev-feedstock.

That feedstock uses:

```yaml
    - {{ compiler('cxx') }}            # [linux]
    - vs2017_{{ target_platform  }}    # [win]
    - clang_bootstrap_osx-64           # [osx]
```

I am assuming that the change to macOS bootstrap is not needed with the current Conda-build since this works fine with the current `compiler('cxx') # [unix]`.

This is just a cleanup so no build number bump needed.