### PR TITLE
Depend on libllvm9 instead of llvmdev

### DIFF
--- a/.ci_support/osx_python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_python3.6.____73_pypy.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.6.____cpython.yaml
+++ b/.ci_support/osx_python3.6.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.8.____cpython.yaml
+++ b/.ci_support/osx_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,11 @@ requirements:
     - make                   # [unix]
   host:
     - python
-    - llvmdev 9.0.*
+    - llvm 9.0.*
     - zlib
     - vs2015_runtime  # [win]
   run:
     - python
-    - libllvm9
     - zlib
     - vs2015_runtime  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
     - make                   # [unix]
   host:
     - python
-    - llvmdev 9.0.*  # [win]
-    - llvm 9.0.*     # [not win]
+    - llvmdev 9.0.*
+    - llvm 9.0.*
     - zlib
     - vs2015_runtime  # [win]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   patches: utils_add_dll.patch  # [win and py>=38]
 
 build:
-  number: 0
+  number: 1
   script_env:
     - PY_VCRUNTIME_REDIST
   # testing just windows for now, after integration we should remove it
@@ -33,7 +33,7 @@ requirements:
     - vs2015_runtime  # [win]
   run:
     - python
-    - llvmdev 9.0.*
+    - libllvm9
     - zlib
     - vs2015_runtime  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - make                   # [unix]
   host:
     - python
-    - llvm 9.0.*
+    - llvmdev 9.0.*  # [win]
+    - llvm 9.0.*     # [not win]
     - zlib
     - vs2015_runtime  # [win]
   run:


### PR DESCRIPTION
`llvmdev` is quite a heavy dependency whereas this only needs the shared libraries.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
