### PR TITLE
Switched to static linking of llvm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham @marcelotrevisani @mbargull @souravsingh @xhochy
+* @beckermr @jakirkham @marcelotrevisani @mbargull @souravsingh @xhochy

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@beckermr](https://github.com/beckermr/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@marcelotrevisani](https://github.com/marcelotrevisani/)
 * [@mbargull](https://github.com/mbargull/)

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,7 @@
 bot:
+  update_static_libs: true
   abi_migration_branches:
-  - rc
+    - rc
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,8 @@ export LLVMLITE_SHARED=0
 if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+elif [[ "${target_platform}" == linux-ppc64le ]]; then
+    CXXFLAGS="${CXXFLAGS} -fplt"
 fi
 
 $PYTHON setup.py build --force

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,11 +5,7 @@ set -x
 export PYTHONNOUSERSITE=1
 
 export LLVMLITE_USE_CMAKE=1
-if [[ "${target_platform}" == "linux-ppc64le" ]]; then
-    export LLVMLITE_SHARED=1
-else
-    export LLVMLITE_SHARED=0
-fi
+export LLVMLITE_SHARED=0
 
 if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,11 @@ set -x
 export PYTHONNOUSERSITE=1
 
 export LLVMLITE_USE_CMAKE=1
-export LLVMLITE_SHARED=1
+if [[ "${target_platform}" == "linux-ppc64le" ]]; then
+    export LLVMLITE_SHARED=1
+else
+    export LLVMLITE_SHARED=0
+fi
 
 if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,12 @@ if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 elif [[ "${target_platform}" == linux-ppc64le ]]; then
-    CXXFLAGS="${CXXFLAGS} -fplt"
+    # Taken from llvmdev's recipe
+    # https://github.com/conda-forge/llvmdev-feedstock/blob/8c2c0f2db9db1fdf12289381dcee4e2d9a2e5fec/recipe/build.sh#L29-L33
+    # disable `-fno-plt` due to some GCC bug causing linker errors, see
+    # https://github.com/llvm/llvm-project/issues/51205
+    CFLAGS="$(echo $CFLAGS | sed 's/-fno-plt //g')"
+    CXXFLAGS="$(echo $CXXFLAGS | sed 's/-fno-plt //g')"
 fi
 
 $PYTHON setup.py build --force

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,12 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   script_env:
     - PY_VCRUNTIME_REDIST
+  ignore_run_exports:
+    - libllvm15  # [unix and not ppc64le]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,8 @@ requirements:
   host:
     - python
     - setuptools
-    - llvmdev 15.0.*
+    - llvmdev 15.0.*        # abstract pin for static lib
+    - llvmdev 15.0.7 *_5    # concrete pin for static lib - bot should update
     - zlib
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,6 @@ source:
 build:
   number: 1
   skip: true  # [py<310]
-  script_env:
-    - PY_VCRUNTIME_REDIST
-  ignore_run_exports:
-    - libllvm15  # [unix and not ppc64le]
 
 requirements:
   build:
@@ -32,12 +28,9 @@ requirements:
     - python
     - setuptools
     - llvmdev 15.0.*
-    - llvm 15.0.*
     - zlib
-    - vs2015_runtime  # [win]
   run:
     - python
-    - vs2015_runtime  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,3 +55,4 @@ extra:
     - marcelotrevisani
     - xhochy
     - mbargull
+    - beckermr


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I switched to static linking of libllvm here and added it to the ignore_run_exports on unix. I did not change the build behaviour on Windows as it seems to already build with default settings there and I have no means to test it.

This fixes #99 and #84.

Reasons against this PR:
- Obviously this will increase binary size, because libllvm is now statically linked. Im explicitly tagging @xhochy here, because he was against static linking this.
- If the symbol version issue would be identified and resolved it would be cleaner

Reasons to merge this PR:
-  It resolves a hard to debug issue, which occurs using libraries, where debugging skill is required to find out, why a segmentation fault actually happened
- It can easily be reverted, once the symbol isolation is gone.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
